### PR TITLE
setting the name of a new invoice to / in order to maintain proper seq

### DIFF
--- a/hr_expense_invoice/models/hr_expense.py
+++ b/hr_expense_invoice/models/hr_expense.py
@@ -43,6 +43,7 @@ class HrExpense(models.Model):
         invoice = self.env["account.move"].create(
             [
                 {
+                    "name": "/",
                     "ref": self.reference,
                     "move_type": "in_invoice",
                     "invoice_date": self.date,


### PR DESCRIPTION
Hello @nicomacr 
Thanks for giving the time to migrate this module.
Please check this PR where I am trying to fix the issue with the wrong sequence numbers when an invoice is created from an expense.
I added `"name": /` in the `action_expense_create_invoice` as this will make sure the name of the invoice stays as draft.

Please merge this fix in your fork to carry these changes to the oca upstream

Thanks